### PR TITLE
Add dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,5 @@ dist/
 # Temporary folders
 tmp/
 temp/
-output/ 
 
 # End of https://www.gitignore.io/api/node

--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,6 @@ dist/
 # Temporary folders
 tmp/
 temp/
+output/ 
 
 # End of https://www.gitignore.io/api/node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:alpine3.11
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install
+COPY tsconfig.json index.ts entrypoint.sh ./
+CMD ["sh", "entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ yarn install
 yarn start
 ```
 
+#### with docker 
+
+```
+$ docker build -t export-qiita .
+$ docker run -it -v `pwd`/output:/tmp/output export-qiita
+```
+
 ### output sample
 ```
 cd output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+yarn start
+cp -r output/* /tmp/output


### PR DESCRIPTION
　Dockerfileを追加しました。
プログラムが固定値で `./output` に出力する仕様だったため、それらの内容を `/tmp/output` にコピーしてホストに返す様にしました。 `/tmp/output` に対してホストをマウントしないとコピーが失敗するため、そのあたりの利便性は改善課題です。

　また上記に伴い、実行コマンドを `README.md` に追加しました。

## TODO
- Dockerfile の MultiStageBuild化